### PR TITLE
Fix possible silent errors on Travis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
 all: iOS9
 
 iOS9:
-	xcodebuild test -scheme Reactor-iOS -sdk iphonesimulator -enableCodeCoverage YES | xcpretty
+	set -o pipefail && xcodebuild test -scheme Reactor-iOS -sdk iphonesimulator -enableCodeCoverage YES | xcpretty


### PR DESCRIPTION
Because we're piping `xcodebuild` through `xcpretty` we need to guarantee that we exit with same status code as `xcodebuild` otherwise we can have some false positives caused by `xcpretty` which always succeeds since he hasn't in consideration the exit code of `xcodebuild.`

Reference: https://github.com/supermarin/xcpretty#usage.

P.S. My apologies, I'm aware that I originated this issue 😞
